### PR TITLE
fix(panel): Display 'touched' and 'dirty' correctly on nested fields

### DIFF
--- a/src/panel.tsx
+++ b/src/panel.tsx
@@ -65,9 +65,9 @@ function PanelChildren<T, K, L, M, G>({
             const errorMessage = get(error, 'message', undefined);
             const errorType = get(error, 'type', undefined);
             const type = get(value, 'ref.type', undefined);
-            const isTouched = !!get(touchedFields, name);
+            const isTouched = !!get(touchedFields, value._f.name);
             const isNative = !!(value && value._f.ref.type);
-            const isDirty = !!get(dirtyFields, name);
+            const isDirty = !!get(dirtyFields, value._f.name);
             const hasError = !!error;
             const ref = get(value, '_f.ref');
 


### PR DESCRIPTION
To fix https://github.com/react-hook-form/devtools/issues/84

When we use `useForm` with nested fields, `formState.touchedFields` works fine.
However `devtool` doesn't update 'Touched' and 'Dirty'. See the first video.
This PR fixes the issue and display these fields correctly. (See the second video)


### AsIs

https://user-images.githubusercontent.com/6651523/123519721-02a42280-d6e8-11eb-9c17-4bfaa7320969.mov


### ToBe

https://user-images.githubusercontent.com/6651523/123519724-059f1300-d6e8-11eb-8328-5b66608a1316.mov


Thanks!
