### PR TITLE
fix: make `control` and `placement` optional

### DIFF
--- a/src/devTool.tsx
+++ b/src/devTool.tsx
@@ -29,7 +29,7 @@ export const DevTool = (props?: {
     <StateMachineProvider>
       <DevToolUI
         control={(props && props.control) || methods.control}
-        placement={props?.placement ?? 'top-left'}
+        placement={props?.placement}
       />
     </StateMachineProvider>
   );

--- a/src/devTool.tsx
+++ b/src/devTool.tsx
@@ -20,8 +20,8 @@ if (typeof window !== 'undefined') {
 }
 
 export const DevTool = (props?: {
-  control: Control<any>;
-  placement: PLACEMENT;
+  control?: Control<any>;
+  placement?: PLACEMENT;
 }) => {
   const methods = useFormContext();
 


### PR DESCRIPTION
`control` and `placement` can be optional. This allows writing `<DevTool control={control} />` without providing the `placement` property.

I also removed the default value in the `DevTool` component as a default value was already defined in `DevToolUI`.

Important:
The default value in [`DevTool` was `top-left`](https://github.com/react-hook-form/devtools/blob/master/src/devTool.tsx#L32) and the default value in [`DevToolUI` is `top-right`](https://github.com/react-hook-form/devtools/blob/master/src/devToolUI.tsx#L19). So, users that ignored TypeScript types so far and didn't provide a `placement` for `<DevTool>` will have the dev tools moved from left to right. So technically this is a breaking change. Depending on what the intended default placement is, it can be changed in `DevToolUI`.

