### PR TITLE
fix: rm devtools from test

### DIFF
--- a/rollup/writeCjsEntryFile.js
+++ b/rollup/writeCjsEntryFile.js
@@ -13,7 +13,7 @@ function writeCjsEntryFile(
   const contents = `
 'use strict'
 
-if (process.env.NODE_ENV === 'production') {
+if (process.env.NODE_ENV !== 'development') {
   module.exports = {
     DevTool: () => null,
   };


### PR DESCRIPTION
I love devtools, and use it all the time, but Ive ran into issues with my tests locally. This is to set the devtools to only be shown when `process.env.NODE_ENV !== 'development'`. This will cover the original case, and the case where devtools show up in tests which has been causing me issues.
