### PR TITLE
set header bg color explicitly to avoid overwriting by the host app

### DIFF
--- a/src/header.tsx
+++ b/src/header.tsx
@@ -20,6 +20,7 @@ const Header = ({ setVisible, control }: Props) => {
         display: 'flex',
         alignItems: 'center',
         paddingLeft: 10,
+        backgroundColor: 'transparent',
       }}
     >
       <p


### PR DESCRIPTION
In our app we set the <header /> bg color, this rule makes the devtool header invisible. 

This PR is intend to fix this bug.

<img width="277" alt="Screen Shot 2021-11-22 at 9 43 11 AM" src="https://user-images.githubusercontent.com/2429369/142788944-89dc6d59-c8bc-49c1-b0fb-c3e44e922bac.png">
