### PR TITLE
Update: Add cursor: pointer to the state panel button

### DIFF
--- a/src/formStateTable.tsx
+++ b/src/formStateTable.tsx
@@ -111,6 +111,7 @@ const FormStateTable = ({
         textTransform: 'none',
         fontSize: 12,
         lineHeight: '14px',
+        cursor: 'pointer',
       }}
       title="Toggle form state panel"
       onClick={() => {


### PR DESCRIPTION
I would like to set the `cursor` style of the state panel button to `pointer`. 

The reason for it is that I have just recently discovered that it is possible to click on the **Form State: ON / OFF** text and expand table showing the overall state of the form. There is nothing that indicates that this text is clickable, I believe that this small change might improve that. 🙂 