### PR TITLE
fix errorMessage.trim is not a function error

### DIFF
--- a/src/panelTable.tsx
+++ b/src/panelTable.tsx
@@ -213,7 +213,9 @@ const PanelTable = ({
                   ...paraGraphDefaultStyle,
                 }}
               >
-                {errorMessage.trim()}
+                {typeof errorMessage === 'string'
+                  ? errorMessage.trim()
+                  : JSON.stringify(errorMessage)}
               </td>
             </tr>
           )}


### PR DESCRIPTION
fix #106

Credit to @Luc9802 for the fix in the issue