### PR TITLE
Allow style overwrite

### DIFF
--- a/src/devTool.tsx
+++ b/src/devTool.tsx
@@ -2,7 +2,7 @@ import { createStore, StateMachineProvider } from 'little-state-machine';
 import * as React from 'react';
 import { Control, FieldValues, useFormContext } from 'react-hook-form';
 import { v4 as generateUUID } from 'uuid';
-import { DevToolUI } from './devToolUI';
+import { DevToolUI, DevtoolUIProps } from './devToolUI';
 import { useExportControlToExtension } from './extension/useExportControlToExtension';
 import type { PLACEMENT } from './position';
 
@@ -21,11 +21,12 @@ if (typeof window !== 'undefined') {
   );
 }
 
-export const DevTool = <T extends FieldValues>(props?: {
-  id?: string;
-  control?: Control<T>;
-  placement?: PLACEMENT;
-}) => {
+export const DevTool = <T extends FieldValues>(
+  props?: {
+    id?: string;
+    control?: Control<T>;
+  } & Pick<DevtoolUIProps, 'placement' | 'style'>,
+) => {
   const methods = useFormContext();
 
   const uuid = React.useRef('');
@@ -47,6 +48,7 @@ export const DevTool = <T extends FieldValues>(props?: {
       <DevToolUI
         control={props?.control ?? methods.control}
         placement={props?.placement}
+        style={props?.style}
       />
     </StateMachineProvider>
   );

--- a/src/devTool.tsx
+++ b/src/devTool.tsx
@@ -25,7 +25,7 @@ export const DevTool = <T extends FieldValues>(
   props?: {
     id?: string;
     control?: Control<T>;
-  } & Pick<DevtoolUIProps, 'placement' | 'style'>,
+  } & Pick<DevtoolUIProps, 'placement' | 'styles'>,
 ) => {
   const methods = useFormContext();
 
@@ -48,7 +48,7 @@ export const DevTool = <T extends FieldValues>(
       <DevToolUI
         control={props?.control ?? methods.control}
         placement={props?.placement}
-        style={props?.style}
+        styles={props?.styles}
       />
     </StateMachineProvider>
   );

--- a/src/devToolUI.tsx
+++ b/src/devToolUI.tsx
@@ -15,7 +15,7 @@ export interface DevtoolUIProps {
   control: Control<any>;
   placement?: PLACEMENT;
   /** Custom styles for the "show/hide panel" button and for the panel div */
-  style?: {
+  styles?: {
     /** Custom styles for the "show/hide panel" button */
     button?: React.HTMLAttributes<HTMLButtonElement>['style'];
     /** Custom styles for the panel div */
@@ -26,7 +26,7 @@ export interface DevtoolUIProps {
 export const DevToolUI: React.FC<DevtoolUIProps> = ({
   control,
   placement = 'top-right',
-  style,
+  styles,
 }) => {
   const { state, actions } = useStateMachine({
     setVisible,
@@ -69,7 +69,7 @@ export const DevToolUI: React.FC<DevtoolUIProps> = ({
             gridTemplateRows: '40px auto',
             fontFamily:
               "-apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif",
-            ...style?.panel,
+            ...styles?.panel,
           }}
         >
           <Header setVisible={actions.setVisible} control={control} />
@@ -88,7 +88,7 @@ export const DevToolUI: React.FC<DevtoolUIProps> = ({
             padding: 3,
             margin: 0,
             background: 'none',
-            ...style?.button,
+            ...styles?.button,
           }}
         >
           <Logo actions={actions} />

--- a/src/devToolUI.tsx
+++ b/src/devToolUI.tsx
@@ -14,8 +14,11 @@ import { PLACEMENT, getPositionByPlacement } from './position';
 export interface DevtoolUIProps {
   control: Control<any>;
   placement?: PLACEMENT;
+  /** Custom styles for the "show/hide panel" button and for the panel div */
   style?: {
+    /** Custom styles for the "show/hide panel" button */
     button?: React.HTMLAttributes<HTMLButtonElement>['style'];
+    /** Custom styles for the panel div */
     panel?: React.HTMLAttributes<HTMLDivElement>['style'];
   };
 }

--- a/src/devToolUI.tsx
+++ b/src/devToolUI.tsx
@@ -11,14 +11,19 @@ import { useStateMachine } from 'little-state-machine';
 import { setVisible } from './settingAction';
 import { PLACEMENT, getPositionByPlacement } from './position';
 
-interface DevtoolUIProps {
+export interface DevtoolUIProps {
   control: Control<any>;
   placement?: PLACEMENT;
+  style?: {
+    button?: React.HTMLAttributes<HTMLButtonElement>['style'];
+    panel?: React.HTMLAttributes<HTMLDivElement>['style'];
+  };
 }
 
 export const DevToolUI: React.FC<DevtoolUIProps> = ({
   control,
   placement = 'top-right',
+  style,
 }) => {
   const { state, actions } = useStateMachine({
     setVisible,
@@ -61,6 +66,7 @@ export const DevToolUI: React.FC<DevtoolUIProps> = ({
             gridTemplateRows: '40px auto',
             fontFamily:
               "-apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif",
+            ...style?.panel,
           }}
         >
           <Header setVisible={actions.setVisible} control={control} />
@@ -79,6 +85,7 @@ export const DevToolUI: React.FC<DevtoolUIProps> = ({
             padding: 3,
             margin: 0,
             background: 'none',
+            ...style?.button,
           }}
         >
           <Logo actions={actions} />


### PR DESCRIPTION
This PR aims at allowing overwriting UI styles (button and panel) from the `DevTool` component.

## Use case and motivation

I have a lot of forms on my website, and I add a `DevTool` component on each of them in debug mode, but if every form display the "open devtool panel" button at the very same place, it is unusable. To fix this problem, I need to customize the button style, which is impossible for now.

I needed to customize the button style, and assumed that someone could need to customize the panel style, that is why I allowed it too.

## Content

This PR adds a `style` prop to the `DevToolUI` and `DevTool` components (the last merely transfer it to the former).
This `style` prop has 2 optional properties, `button` and `panel` that can receive some styles, spreaded in the button style prop and the the div style prop respectively.
