### PR TITLE
fix: extend generic type parameter for DevTool component

### DIFF
--- a/src/devTool.tsx
+++ b/src/devTool.tsx
@@ -21,10 +21,13 @@ if (typeof window !== 'undefined') {
   );
 }
 
-export const DevTool = <T extends FieldValues>(
+export const DevTool = <
+  TFieldValues extends FieldValues,
+  TTransformedValues = FieldValues,
+>(
   props?: {
     id?: string;
-    control?: Control<T>;
+    control?: Control<TFieldValues, any, TTransformedValues>;
   } & Pick<DevtoolUIProps, 'placement' | 'styles'>,
 ) => {
   const methods = useFormContext();


### PR DESCRIPTION
## Summary
- Extended the generic type parameters for the DevTool component to properly support typed Input/Output interfaces for form validators.
- Enables proper type inference when using the DevTool with strongly-typed form schemas.

## Details
This PR complements the type improvements made in [react-hook-form/resolvers#753](https://github.com/react-hook-form/resolvers/pull/753), which introduced typed Input/Output interfaces for resolvers.