### PR TITLE
Replace lodash with es-toolkit

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,9 +60,8 @@
   "dependencies": {
     "@emotion/react": "^11.1.5",
     "@emotion/styled": "^11.3.0",
-    "@types/lodash": "^4.14.168",
+    "es-toolkit": "^1.39.5",
     "little-state-machine": "^4.1.0",
-    "lodash": "^4.17.21",
     "react-simple-animate": "^3.3.12",
     "use-deep-compare-effect": "^1.8.1",
     "uuid": "^8.3.2"

--- a/src/extension/useExportControlToExtension.ts
+++ b/src/extension/useExportControlToExtension.ts
@@ -1,4 +1,4 @@
-import get from 'lodash/get';
+import get from 'es-toolkit/compat/get';
 import { useEffect, useState } from 'react';
 import { Control, useFormState, useWatch } from 'react-hook-form';
 import useDeepCompareEffect from 'use-deep-compare-effect';
@@ -72,7 +72,7 @@ export function useExportControlToExtension({
 
     const nativeFields = flatFieldNames.reduce((prev, name) => {
       const field = get(control._fields, name)?._f;
-      prev[name] = get(field, 'ref')?.type;
+      prev[name] = (get(field, 'ref') as any)?.type;
       return prev;
     }, {} as Record<string, boolean>);
 

--- a/src/extension/utils.ts
+++ b/src/extension/utils.ts
@@ -1,4 +1,4 @@
-import get from 'lodash/get';
+import get from 'es-toolkit/compat/get';
 
 export function proxyToObject<T extends Record<string, any>>(proxy: T) {
   return Reflect.ownKeys(proxy).reduce((prev, key) => {

--- a/src/panelTable.tsx
+++ b/src/panelTable.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { get } from 'react-hook-form';
-import isUndefined from 'lodash/isUndefined';
-import isObject from 'lodash/isObject';
+import isObject from 'es-toolkit/compat/isObject';
 
 import colors from './colors';
 import { Button, Table, paraGraphDefaultStyle } from './styled';
@@ -43,7 +42,7 @@ const PanelTable = ({
   let value = fieldsValues ? get(fieldsValues, name) : '';
   let isValueWrappedInPre = false;
 
-  if (!isUndefined(value)) {
+  if (value !== undefined) {
     if (isObject(value)) {
       try {
         value = (
@@ -221,7 +220,7 @@ const PanelTable = ({
               </td>
             </tr>
           )}
-          {!isUndefined(value) && (
+          {value !== undefined && (
             <tr>
               <td
                 align="right"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3035,7 +3035,7 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
   integrity sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==
 
-"@types/lodash@^4.14.167", "@types/lodash@^4.14.168":
+"@types/lodash@^4.14.167":
   version "4.14.182"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.182.tgz#05301a4d5e62963227eaafe0ce04dd77c54ea5c2"
   integrity sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q==
@@ -5855,6 +5855,11 @@ es-to-primitive@^1.2.1:
     is-callable "^1.1.4"
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
+
+es-toolkit@^1.39.5:
+  version "1.39.5"
+  resolved "https://registry.yarnpkg.com/es-toolkit/-/es-toolkit-1.39.5.tgz#ee2a78a66aafb76c7345af0ea8c06722c78ef1fd"
+  integrity sha512-z9V0qU4lx1TBXDNFWfAASWk6RNU6c6+TJBKE+FLIg8u0XJ6Yw58Hi0yX8ftEouj6p1QARRlXLFfHbIli93BdQQ==
 
 es5-shim@^4.5.13:
   version "4.6.7"


### PR DESCRIPTION
## Replace lodash with es-toolkit for better performance and smaller bundle size

### Summary
This PR replaces lodash dependencies with es-toolkit to improve performance and reduce bundle size in dev-tools.

### Changes
- **Replaced lodash functions with es-toolkit/compat equivalents:**
  - `get` function: Reduced from 1,279 lines to 175 lines
  - `isObject` function: Using es-toolkit's lodash-compatible version
  - `isUndefined` → Direct JavaScript syntax (`target === undefined`)

### Performance Improvements
- **Bundle size reduction**: Significant decrease in build size due to smaller function implementations
- **Runtime performance**: ~1.5x faster performance in most scenarios according to benchmarks
- **Code optimization**: Removed unnecessary memoization features while maintaining functionality

### Why es-toolkit?
1. **Active maintenance**: Unlike lodash, es-toolkit is actively maintained and optimized
2. **100% compatibility**: es-toolkit/compat passes all lodash test suites and maintains identical interfaces
3. **Industry adoption**: Already used by major projects like Storybook and Recharts
4. **Modern optimization**: Built with modern JavaScript performance optimizations

### Technical Details
The `get` function optimization was achieved by:
- Removing redundant memoization logic
- Streamlining the implementation without sacrificing functionality
- Maintaining full API compatibility through es-toolkit/compat

### Testing
- All existing tests pass without modification
- es-toolkit/compat ensures 100% API compatibility with lodash
- No breaking changes for consumers

### Future Plans

This is part of our ongoing performance improvement initiative. We recommend migrating from the unmaintained lodash to the modern, performant es-toolkit.
