### PR TITLE
fix: remove devtools panel from focus order when closed

### DIFF
--- a/src/devToolUI.tsx
+++ b/src/devToolUI.tsx
@@ -33,6 +33,7 @@ export const DevToolUI: React.FC<DevtoolUIProps> = ({
   });
 
   const position = getPositionByPlacement(placement, 0, 0);
+  const visibility = state.visible ? 'visible' : 'hidden';
 
   return (
     <>
@@ -61,6 +62,7 @@ export const DevToolUI: React.FC<DevtoolUIProps> = ({
             height: '100vh',
             width: 250,
             zIndex: 99999,
+            visibility,
             background: colors.buttonBlue,
             display: 'grid',
             textAlign: 'left',


### PR DESCRIPTION
Fixes #198 

Testing:
- [ ] Ensure `yarn install` has been run in both the repo root and the `example` subdirectory
- [ ] `cd example && yarn run dev`
- [ ] Go to http://localhost:5173
- [ ] Use the Tab key to cycle through links and inputs on the page (Shift+Tab if you need to go backward).
   - [ ] On master, there will be several "invisible" focus stops after the submit button, where you press Tab repeatedly but nothing is focused. These correspond to the unseen inputs inside the hidden DevTools panel, which incorrectly receive focus as described in the linked issue.
   - [ ] On this branch, keyboard focus should go directly from the Submit button to the DevTools logo in the upper right.